### PR TITLE
Adding support to parse arbitrary files (along with dictionary files)

### DIFF
--- a/data/gettysburg_address.txt
+++ b/data/gettysburg_address.txt
@@ -1,0 +1,23 @@
+Four score and seven years ago our fathers brought forth on this
+continent a new nation, conceived in liberty and dedicated to the
+proposition that all men are created equal. Now we are engaged in
+a great civil war, testing whether that nation or any nation so
+conceived and so dedicated can long endure. We are met on a great
+battlefield of that war. We have come to dedicate a portion of
+that field as a final resting-place for those who here gave their
+lives that that nation might live. It is altogether fitting and
+proper that we should do this. But in a larger sense, we cannot
+dedicate, we cannot consecrate, we cannot hallow this ground.
+The brave men, living and dead who struggled here have consecrated
+it far above our poor power to add or detract. The world will
+little note nor long remember what we say here, but it can never
+forget what they did here. It is for us the living rather to be
+dedicated here to the unfinished work which they who fought here
+have thus far so nobly advanced. It is rather for us to be here
+dedicated to the great task remaining before us--that from these
+honored dead we take increased devotion to that cause for which
+they gave the last full measure of devotion--that we here highly
+resolve that these dead shall not have died in vain, that this
+nation under God shall have a new birth of freedom, and that
+government of the people, by the people, for the people shall
+not perish from the earth.

--- a/src/autocompleter.rs
+++ b/src/autocompleter.rs
@@ -42,7 +42,7 @@ impl Autocompleter {
     /// # Return value
     ///
     /// Either the constructed `Autocompleter`, or a `Error` with the error string.
-    pub fn from_dict(dict_filename: &String) -> Result<Autocompleter, String> {
+    pub fn from_file(dict_filename: &String) -> Result<Autocompleter, String> {
         let mut val = Autocompleter::new();
 
         // Try to open the file for reading, or bail out if an error occurs.
@@ -55,7 +55,11 @@ impl Autocompleter {
         let reader = BufReader::new(dict_file);
         for line in reader.lines() {
             match line {
-                Ok(l) => val.trie.add_record(l),
+                Ok(l) => {
+                    for word in l.split_whitespace() {
+                        val.trie.add_record(word.to_string());
+                    }
+                }
                 Err(e) => return Err(format!("Error reading line from file: {e}")),
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -81,7 +81,7 @@ fn main() -> ExitCode {
     let mut ac = if conf.filename.as_str() == "" {
         Autocompleter::new()
     } else {
-        match Autocompleter::from_dict(&conf.filename) {
+        match Autocompleter::from_file(&conf.filename) {
             Ok(acc) => acc,
             Err(e) => {
                 eprintln!("{}", e);

--- a/src/main.rs
+++ b/src/main.rs
@@ -84,7 +84,7 @@ fn main() -> ExitCode {
         match Autocompleter::from_file(&conf.filename) {
             Ok(acc) => acc,
             Err(e) => {
-                eprintln!("{}", e);
+                eprintln!("{e}");
                 exit(1);
             }
         }


### PR DESCRIPTION
Closes #1 

This is a first attempt to use any files, not just dictionary files, as input to the completer for predictions that also make use of the frequency analysis portion.

Currently, the program doesn't ignore punctuation yet so that is coming in a later fix.

Also added a text file of the gettysburg address for testing purposes in the `data` directory.