### PR TITLE
moving from tuple to struct for maintainability

### DIFF
--- a/src/autocompleter.rs
+++ b/src/autocompleter.rs
@@ -36,7 +36,7 @@ struct SortResult {
 
 impl SortResult {
     fn new(count: i32, data: String) -> SortResult {
-        SortResult { count, data, }
+        SortResult { count, data }
     }
 }
 

--- a/src/autocompleter.rs
+++ b/src/autocompleter.rs
@@ -27,6 +27,7 @@ pub struct Autocompleter {
 /// # Fields
 ///
 /// `count` (`i32`) - number of instances of a particular word
+///
 /// `data` (`String`) - the word itself
 struct SortResult {
     count: i32,


### PR DESCRIPTION
Closes #5 

Moving from
```rust
type RetTup = (i32, String);
```
to
```rust
struct SortResult {
  count: i32,
  data: String,
}
```

This change allows us to go from code that looks like
```rust
dfs_results.sort_by(|a, b| b.0.cmp(&a.0));
```
to
```rust
dfs.results.sort_by(|a, b| b.count.cmp(&a.count));
```